### PR TITLE
Amended comment to match the order of magnitude or rate which is REQU…

### DIFF
--- a/waf-reactive-blacklist/waf_template.json
+++ b/waf-reactive-blacklist/waf_template.json
@@ -49,7 +49,7 @@
     "RequestThreshold": {
       "Type": "Number",
       "Default": "400",
-      "Description": "Enter the maximum acceptable request per second per IP address. Default: 400 requests per minute"
+      "Description": "Enter the maximum acceptable request per minute per IP address. Default: 400 requests per minute"
     },
     "WAFBlockPeriod": {
       "Type": "Number",


### PR DESCRIPTION
…EST_PER_MINUTE_LIMIT, as it was contradictory and instructing entry of a rate per second.