### PR TITLE
IPSet limit fix

### DIFF
--- a/waf-reputation-lists/cloudformation.json
+++ b/waf-reputation-lists/cloudformation.json
@@ -21,6 +21,84 @@
                 "Name": "IP Set #2"
             }
         },
+		"WAFIPSet3": {
+            "Type": "AWS::WAF::IPSet",
+            "Properties": {
+                "Name": "IP Set #3"
+            }
+        },
+        "WAFIPSet4": {
+            "Type": "AWS::WAF::IPSet",
+            "Properties": {
+                "Name": "IP Set #4"
+            }
+        },
+"WAFIPSet5": {
+            "Type": "AWS::WAF::IPSet",
+            "Properties": {
+                "Name": "IP Set #5"
+            }
+        },
+        "WAFIPSet6": {
+            "Type": "AWS::WAF::IPSet",
+            "Properties": {
+                "Name": "IP Set #6"
+            }
+        },
+"WAFIPSet7": {
+            "Type": "AWS::WAF::IPSet",
+            "Properties": {
+                "Name": "IP Set #7"
+            }
+        },
+        "WAFIPSet8": {
+            "Type": "AWS::WAF::IPSet",
+            "Properties": {
+                "Name": "IP Set #8"
+            }
+        },
+        "WAFIPSet9": {
+            "Type": "AWS::WAF::IPSet",
+            "Properties": {
+                "Name": "IP Set #9"
+            }
+        },
+        "WAFIPSet10": {
+            "Type": "AWS::WAF::IPSet",
+            "Properties": {
+                "Name": "IP Set #10"
+            }
+        },
+        "WAFIPSet11": {
+            "Type": "AWS::WAF::IPSet",
+            "Properties": {
+                "Name": "IP Set #11"
+            }
+        },
+        "WAFIPSet12": {
+            "Type": "AWS::WAF::IPSet",
+            "Properties": {
+                "Name": "IP Set #12"
+            }
+        },
+		"WAFIPSet13": {
+            "Type": "AWS::WAF::IPSet",
+            "Properties": {
+                "Name": "IP Set #13"
+            }
+        },
+        "WAFIPSet14": {
+            "Type": "AWS::WAF::IPSet",
+            "Properties": {
+                "Name": "IP Set #14"
+            }
+        },
+		"WAFIPSet15": {
+            "Type": "AWS::WAF::IPSet",
+            "Properties": {
+                "Name": "IP Set #15"
+            }
+        },
         "WAFRule1": {
             "Type": "AWS::WAF::Rule",
             "Properties": {
@@ -32,7 +110,35 @@
                             "Ref": "WAFIPSet1"
                         },
                         "Type": "IPMatch",
-                        "Negated": "false"
+                        "Negated": "true"
+                    },
+                    {
+                        "DataId": {
+                            "Ref": "WAFIPSet2"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "true"
+                    },
+                    {
+                        "DataId": {
+                            "Ref": "WAFIPSet3"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "true"
+                    },
+                    {
+                        "DataId": {
+                            "Ref": "WAFIPSet4"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "true"
+                    },
+                    {
+                        "DataId": {
+                            "Ref": "WAFIPSet5"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "true"
                     }
                 ]
             }
@@ -45,10 +151,82 @@
                 "Predicates": [
                     {
                         "DataId": {
-                            "Ref": "WAFIPSet2"
+                            "Ref": "WAFIPSet6"
                         },
                         "Type": "IPMatch",
-                        "Negated": "false"
+                        "Negated": "true"
+                    },
+                    {
+                        "DataId": {
+                            "Ref": "WAFIPSet7"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "true"
+                    },
+                    {
+                        "DataId": {
+                            "Ref": "WAFIPSet8"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "true"
+                    },
+                    {
+                        "DataId": {
+                            "Ref": "WAFIPSet9"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "true"
+                    },
+                    {
+                        "DataId": {
+                            "Ref": "WAFIPSet10"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "true"
+                    }
+                ]
+            }
+        },
+        "WAFRule3": {
+            "Type": "AWS::WAF::Rule",
+            "Properties": {
+                "Name": "WAF Rule #3",
+                "MetricName": "WAFRule3",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFIPSet11"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "true"
+                    },
+                    {
+                        "DataId": {
+                            "Ref": "WAFIPSet12"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "true"
+                    },
+                    {
+                        "DataId": {
+                            "Ref": "WAFIPSet13"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "true"
+                    },
+                    {
+                        "DataId": {
+                            "Ref": "WAFIPSet14"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "true"
+                    },
+                    {
+                        "DataId": {
+                            "Ref": "WAFIPSet15"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "true"
                     }
                 ]
             }
@@ -58,13 +236,13 @@
             "Properties": {
                 "Name": "WebACL",
                 "DefaultAction": {
-                    "Type": "ALLOW"
+                    "Type": "BLOCK"
                 },
                 "MetricName": "MaliciousRequesters",
                 "Rules": [
                     {
                         "Action": {
-                            "Type": "BLOCK"
+                            "Type": "ALLOW"
                         },
                         "Priority": 1,
                         "RuleId": {
@@ -73,11 +251,20 @@
                     },
                     {
                         "Action": {
-                            "Type": "BLOCK"
+                            "Type": "ALLOW"
                         },
                         "Priority": 2,
                         "RuleId": {
                             "Ref": "WAFRule2"
+                        }
+                    },
+                    {
+                        "Action": {
+                            "Type": "ALLOW"
+                        },
+                        "Priority": 3,
+                        "RuleId": {
+                            "Ref": "WAFRule3"
                         }
                     }
                 ]
@@ -164,6 +351,201 @@
                                                     }
                                                 ]
                                             ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:waf::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":ipset/",
+                                                    {
+                                                        "Ref": "WAFIPSet3"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:waf::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":ipset/",
+                                                    {
+                                                        "Ref": "WAFIPSet4"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:waf::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":ipset/",
+                                                    {
+                                                        "Ref": "WAFIPSet5"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:waf::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":ipset/",
+                                                    {
+                                                        "Ref": "WAFIPSet6"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:waf::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":ipset/",
+                                                    {
+                                                        "Ref": "WAFIPSet7"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:waf::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":ipset/",
+                                                    {
+                                                        "Ref": "WAFIPSet8"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:waf::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":ipset/",
+                                                    {
+                                                        "Ref": "WAFIPSet9"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:waf::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":ipset/",
+                                                    {
+                                                        "Ref": "WAFIPSet10"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:waf::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":ipset/",
+                                                    {
+                                                        "Ref": "WAFIPSet11"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:waf::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":ipset/",
+                                                    {
+                                                        "Ref": "WAFIPSet12"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:waf::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":ipset/",
+                                                    {
+                                                        "Ref": "WAFIPSet13"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:waf::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":ipset/",
+                                                    {
+                                                        "Ref": "WAFIPSet14"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:waf::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":ipset/",
+                                                    {
+                                                        "Ref": "WAFIPSet15"
+                                                    }
+                                                ]
+                                            ]
                                         }
                                     ]
                                 }
@@ -197,7 +579,7 @@
                     },
                     "S3Key": "waf-reputation-lists/lambda.zip"
                 },
-                "Runtime": "nodejs",
+                "Runtime": "nodejs4.3",
                 "MemorySize": "512",
                 "Timeout": "60"
             }
@@ -234,6 +616,71 @@
                                     "\"",
                                     {
                                         "Ref": "WAFIPSet2"
+                                    },
+                                    "\",",
+                                    "\"",
+                                    {
+                                        "Ref": "WAFIPSet3"
+                                    },
+                                    "\",",
+                                    "\"",
+                                    {
+                                        "Ref": "WAFIPSet4"
+                                    },
+                                    "\",",
+                                    "\"",
+                                    {
+                                        "Ref": "WAFIPSet5"
+                                    },
+                                    "\",",
+                                    "\"",
+                                    {
+                                        "Ref": "WAFIPSet6"
+                                    },
+                                    "\",",
+                                    "\"",
+                                    {
+                                        "Ref": "WAFIPSet7"
+                                    },
+                                    "\",",
+                                    "\"",
+                                    {
+                                        "Ref": "WAFIPSet8"
+                                    },
+                                    "\",",
+                                    "\"",
+                                    {
+                                        "Ref": "WAFIPSet9"
+                                    },
+                                    "\",",
+                                    "\"",
+                                    {
+                                        "Ref": "WAFIPSet10"
+                                    },
+                                    "\",",
+                                    "\"",
+                                    {
+                                        "Ref": "WAFIPSet11"
+                                    },
+                                    "\",",
+                                    "\"",
+                                    {
+                                        "Ref": "WAFIPSet12"
+                                    },
+                                    "\",",
+                                    "\"",
+                                    {
+                                        "Ref": "WAFIPSet13"
+                                    },
+                                    "\",",
+                                    "\"",
+                                    {
+                                        "Ref": "WAFIPSet14"
+                                    },
+                                    "\",",
+                                    "\"",
+                                    {
+                                        "Ref": "WAFIPSet15"
                                     },
                                     "\"",
                                     "]}"


### PR DESCRIPTION
Added 15 IPSets to allow for the aprox 12k CIDR ranges currently
produced from the 3 source lists.

To accomodate this volume of CIDR ranges changed to 3 Rules with 5
IPSets each and changed each Condition to ‘negated’, Rules to ALLOW,
and default ACL action to BLOCK.

This structure change gets around the hard account limits as described
here:   http://docs.aws.amazon.com/waf/latest/developerguide/limits.html

… given the constraints of WAF as described here:
“If you add more than one predicate to a rule, a request must match all
conditions in order to be allowed or blocked.”
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resour
ce-waf-rule.html#cfn-waf-rule-predicates

Also set the Lambda NodeJS version to 4.3 to avoid warning message in
console.